### PR TITLE
Alpha3

### DIFF
--- a/fsh-generated/resources/StructureDefinition-ext-R5-Observation.triggeredBy.json
+++ b/fsh-generated/resources/StructureDefinition-ext-R5-Observation.triggeredBy.json
@@ -1,66 +1,6 @@
 {
   "resourceType": "StructureDefinition",
   "id": "ext-R5-Observation.triggeredBy",
-  "extension": [
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
-      "valueCode": "fhir"
-    },
-    {
-      "extension": [
-        {
-          "url": "packageId",
-          "valueId": "hl7.fhir.uv.xver-r5.r4"
-        },
-        {
-          "url": "version",
-          "valueString": "0.1.0"
-        },
-        {
-          "url": "uri",
-          "valueUri": "http://hl7.org/fhir/uv/xver/ImplementationGuide/hl7.fhir.uv.xver-r5.r4"
-        }
-      ],
-      "url": "http://hl7.org/fhir/StructureDefinition/package-source"
-    },
-    {
-      "extension": [
-        {
-          "url": "startFhirVersion",
-          "valueCode": "4.0"
-        },
-        {
-          "url": "endFhirVersion",
-          "valueCode": "4.0"
-        }
-      ],
-      "url": "http://hl7.org/fhir/StructureDefinition/version-specific-use"
-    },
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
-      "valueInteger": 0,
-      "_valueInteger": {
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-conformance-derivedFrom",
-            "valueCanonical": "http://hl7.org/fhir/uv/xver/ImplementationGuide/hl7.fhir.uv.xver-r5.r4"
-          }
-        ]
-      }
-    },
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-      "valueCode": "trial-use",
-      "_valueCode": {
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-conformance-derivedFrom",
-            "valueCanonical": "http://hl7.org/fhir/uv/xver/ImplementationGuide/hl7.fhir.uv.xver-r5.r4"
-          }
-        ]
-      }
-    }
-  ],
   "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy",
   "version": "0.1.0",
   "name": "ExtensionObservation_TriggeredBy",

--- a/implementation-guides/modulmikrobio-2027/MIIIGModulMikrobiologie/Changelog.page.md
+++ b/implementation-guides/modulmikrobio-2027/MIIIGModulMikrobiologie/Changelog.page.md
@@ -4,8 +4,25 @@ Dieses Dokument beschreibt die wesentlichen Änderungen je Release des IGs.
 
 | Version | Datum | Typ | Inhalt |
 |---------|-------|-----|--------|
+| 2027.0.0-alpha.3 | 13.05.2026 | Technischer Hotfix (Preview) | Backport der R5-Extension `extension-Observation.triggeredBy` als lokales Artefakt zur Stabilisierung der Snapshot-Generierung, solange Simplifier die `xver`-Packages noch nicht unterstützt. |
 | 2027.0.0-alpha.2 | 16.04.2026 | Inhaltliche Aktualisierung (Preview) | Bindings in mehreren Profilen von `required` auf `extensible` gelockert, Methodenbindung für Resistenzmechanismen auf neues ValueSet umgestellt, DiagnosticReport-Kategorie auf MB inkl. Coding-Slice und optionalen LOINC-Befundtyp (`mibi-sub-category`) ausgerichtet sowie Terminologieinhalte für Avidität/Morphologie erweitert. |
 | 2027.0.0-alpha.1 | 14.04.2026 | Breaking (Preview) | National und europäisch abgestimmte Neuausrichtung der Mikrobiologie-Modellierung mit neuen/ersetzten Profil-URLs (Canonicals), Observation-orientierter Struktur ohne `Observation.component`, aktualisierten Terminologiebindungen sowie überarbeiteter IG-Navigation. |
+
+### 2027.0.0-alpha.3
+
+#### High-Level (Was hat sich fachlich geändert?)
+
+- Für `extension-Observation.triggeredBy` wurde ein lokaler Backport ergänzt, weil Simplifier aktuell die `xver`-Packages noch nicht verarbeitet und dadurch Snapshot-Generierung fehlschlagen kann.
+- Die Maßnahme ist als technischer Workaround gedacht und soll zurückgenommen werden, sobald `xver` in Simplifier unterstützt wird.
+- Es gibt keine fachliche Änderung an der Modellsemantik, nur eine technische Absicherung für Build/Publishing.
+
+#### Detaillierte Änderungen für Implementierer (pro Artefakt-URL / Canonical)
+
+##### Extension / Logical Model / CapabilityStatement
+
+| Artefakt (Canonical-URL) | Änderungstyp | Vorher (falls relevant) | Nachher | Implementierungsauswirkung | Migrationshinweis |
+|-------------|--------------|--------------------------|---------|----------------------------|-------------------|
+| `extension-Observation.triggeredBy` | technisch aktualisiert (Backport) | Referenz auf externe R5/XVer-Definition; Snapshot-Generierung auf Simplifier teilweise fehleranfällig | Lokale Backport-Definition als Workaround ergänzt, bis Simplifier `xver` unterstützt | Stabilere Snapshot-Generierung im aktuellen Tooling | Nach verfügbarer `xver`-Unterstützung lokalen Backport entfernen und Dependency wieder direkt nutzen |
 
 ### 2027.0.0-alpha.2
 

--- a/input/fsh/extensions/ExtensionObservation_TriggeredBy.fsh
+++ b/input/fsh/extensions/ExtensionObservation_TriggeredBy.fsh
@@ -7,28 +7,6 @@ Id: ext-R5-Observation.triggeredBy
 Title: "R5: Triggering observation(s) (new)"
 Description: "R5: `Observation.triggeredBy` (new:BackboneElement)"
 Context: Observation
-* ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg"
-* ^extension[=].valueCode = #fhir
-* ^extension[+].extension[0].url = "packageId"
-* ^extension[=].extension[=].valueId = "hl7.fhir.uv.xver-r5.r4"
-* ^extension[=].extension[+].url = "version"
-* ^extension[=].extension[=].valueString = "0.1.0"
-* ^extension[=].extension[+].url = "uri"
-* ^extension[=].extension[=].valueUri = "http://hl7.org/fhir/uv/xver/ImplementationGuide/hl7.fhir.uv.xver-r5.r4"
-* ^extension[=].url = "http://hl7.org/fhir/StructureDefinition/package-source"
-* ^extension[+].extension[0].url = "startFhirVersion"
-* ^extension[=].extension[=].valueCode = #4.0
-* ^extension[=].extension[+].url = "endFhirVersion"
-* ^extension[=].extension[=].valueCode = #4.0
-* ^extension[=].url = "http://hl7.org/fhir/StructureDefinition/version-specific-use"
-* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm"
-* ^extension[=].valueInteger = 0
-* ^extension[=].valueInteger.extension.url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-conformance-derivedFrom"
-* ^extension[=].valueInteger.extension.valueCanonical = "http://hl7.org/fhir/uv/xver/ImplementationGuide/hl7.fhir.uv.xver-r5.r4"
-* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status"
-* ^extension[=].valueCode = #trial-use
-* ^extension[=].valueCode.extension.url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-conformance-derivedFrom"
-* ^extension[=].valueCode.extension.valueCanonical = "http://hl7.org/fhir/uv/xver/ImplementationGuide/hl7.fhir.uv.xver-r5.r4"
 * ^url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy"
 * ^version = "0.1.0"
 * ^experimental = false


### PR DESCRIPTION
This pull request introduces a technical hotfix to stabilize the snapshot generation process by backporting the R5 extension `extension-Observation.triggeredBy` as a local artifact. This is a temporary workaround for current tooling limitations (specifically, Simplifier not yet supporting the required `xver` packages) and does not affect the semantic content of the IG. The workaround will be removed once upstream support is available.

Key changes:

**Extension Backport and Metadata Simplification**
- Removed all package source, version-specific, and conformance metadata from the local definition of `ExtensionObservation_TriggeredBy` in both the FSH (`ExtensionObservation_TriggeredBy.fsh`) and generated StructureDefinition JSON (`StructureDefinition-ext-R5-Observation.triggeredBy.json`). This ensures the extension is defined locally, independent of external `xver` packages, to prevent snapshot generation errors. [[1]](diffhunk://#diff-611da9b750880c70f5fd5df8c9b86d17ba6a7ac82b7bb5b4384db011cee46bccL10-L31) [[2]](diffhunk://#diff-904777f80ddbf53aad605ce01e26ee3ef8aea1a9ed636427e5af44036eb322e0L4-L63)

**Documentation and Changelog Updates**
- Updated the changelog (`Changelog.page.md`) to document the addition of the local backport, clarify its technical nature, and provide implementation guidance for users. The changelog notes that this is a non-semantic, technical measure and should be reverted once the tooling supports direct use of the `xver` package.