### PR TITLE
fix(nugent-score): Pattern auf unit entfernen + Wertebereichs-Invariante

### DIFF
--- a/input/fsh/profiles/MII_PR_Mikrobio_Nugent_Score.fsh
+++ b/input/fsh/profiles/MII_PR_Mikrobio_Nugent_Score.fsh
@@ -6,7 +6,13 @@ Description: "Nugent-Score beschreibt ein Gramfärbungs-basiertes semiquantitati
 * insert MIKRO_OBSERVATION_COMMON
 * code = $loinc#101433-1
 * value[x] only Quantity
+* valueQuantity obeys nugent-score-0-to-10
 * valueQuantity
-  * unit = "1"
+  * ^comment = "Der Nugent Score ist ein dimensionsloser Score von 0 bis 10. In UCUM wird daher code = \"1\" verwendet. Die menschenlesbare Einheit kann über Quantity.unit, z. B. \"Nugent score\", angegeben werden."
   * code = #1
 * method = $sct#702661004
+
+Invariant: nugent-score-0-to-10
+Description: "Nugent score SHALL be between 0 and 10."
+Expression: "value >= 0 and value <= 10"
+Severity: #error


### PR DESCRIPTION
## Zusammenfassung
- Entfernt das Pattern `* unit = "1"` auf `valueQuantity` in `MII_PR_Mikrobio_Nugent_Score`, sodass die menschenlesbare Einheit frei über `Quantity.unit` (z. B. "Nugent score") angegeben werden kann. Der dimensionslose UCUM-`code = #1` bleibt erhalten.
- Ergänzt die Guidance als `^comment` auf `valueQuantity`.
- Fügt die Invariante `nugent-score-0-to-10` (`value >= 0 and value <= 10`, Severity `#error`) hinzu.

## Hintergrund
Der Nugent Score ist ein dimensionsloser Score von 0 bis 10. In UCUM wird daher `code = "1"` verwendet; die Einheit soll nicht per Pattern fixiert werden.

Closes #79