### PR TITLE
docs(mikrobio): Technologieoffene IG-Definitionen (#77)

### DIFF
--- a/input/fsh/profiles/MII_PR_Mikrobio_Resistenzmechanismen_Determinanten.fsh
+++ b/input/fsh/profiles/MII_PR_Mikrobio_Resistenzmechanismen_Determinanten.fsh
@@ -2,7 +2,7 @@ Profile: MII_PR_Mikrobio_Resistenzmechanismen_Determinanten
 Parent: MII_PR_Labor_Laboruntersuchung
 Id: mii-pr-mikrobio-resistenzmechanismen-determinanten
 Title: "MII PR Mikrobio Resistenzmechanismen Determinanten"
-Description: "Resistenzmechanismen/Determinanten beschreibt den Nachweis von Resistenzgenen oder Resistenzmutationen in einer Probe als Hinweis auf spezifische Resistenzmechanismen."
+Description: "Resistenzmechanismen/Determinanten beschreibt den Nachweis von Resistenzgenen, Resistenzmutationen, Proteinen oder funktionalen Test (z.B. CIM-Test) in einer Probe oder Isolat als Hinweis auf spezifische Resistenzmechanismen."
 * insert MIKRO_OBSERVATION_COMMON
 * ^purpose = "Dieses Profil beschreibt den Nachweis von Resistenzmechanismen und Determinanten." 
 * code from MII_VS_Mikrobio_Resistenzmechanismen_Determinanten_LOINC (extensible)

--- a/input/fsh/profiles/MII_PR_Mikrobio_Virulenzfaktor.fsh
+++ b/input/fsh/profiles/MII_PR_Mikrobio_Virulenzfaktor.fsh
@@ -2,7 +2,7 @@ Profile: MII_PR_Mikrobio_Virulenzfaktor
 Parent: MII_PR_Labor_Laboruntersuchung
 Id: mii-pr-mikrobio-virulenzfaktor
 Title: "MII PR Mikrobio Virulenzfaktor"
-Description: "Virulenzfaktor beschreibt den qualitativen Nachweis oder Ausschluss von Virulenzdeterminanten in einer Probe."
+Description: "Virulenzfaktor beschreibt den qualitativen Nachweis oder Ausschluss von Virulenzdeterminanten in einer Probe oder einem Isolat."
 * insert MIKRO_OBSERVATION_COMMON
 * ^purpose = "Dieses Profil beschreibt den Nachweis von Virulenzfaktoren." 
 * code from MII_VS_Mikrobio_Virulenz_LOINC (extensible)

--- a/input/fsh/profiles/MII_PR_Mikrobio_Voraussichtliche_Empfindlichkeit.fsh
+++ b/input/fsh/profiles/MII_PR_Mikrobio_Voraussichtliche_Empfindlichkeit.fsh
@@ -2,7 +2,7 @@ Profile: MII_PR_Mikrobio_Voraussichtliche_Empfindlichkeit
 Parent: MII_PR_Labor_Laboruntersuchung
 Id: mii-pr-mikrobio-voraussichtliche-empfindlichkeit
 Title: "MII PR Mikrobio Voraussichtliche Empfindlichkeit"
-Description: "Voraussichtliche Empfindlichkeit beschreibt eine aus genotypischen Nachweisen abgeleitete erwartete Suszeptibilität oder Resistenz gegenüber antimikrobiellen Substanzen."
+Description: "Voraussichtliche Empfindlichkeit beschreibt die aus dem Nachweis von Resistenzmechanismen/Genen/Proteinen abgeleitete erwartete Suszeptibilität oder Resistenz gegenüber antimikrobiellen Substanzen."
 * insert MIKRO_OBSERVATION_COMMON
 * ^purpose = "Dieses Profil beschreibt die voraussichtliche Empfindlichkeit." 
 * code from MII_VS_Mikrobio_Empfaenglichkeit_Genotyp_LOINC (extensible)


### PR DESCRIPTION
## Zusammenfassung
Aktualisiert drei Profil-Definitionen, damit sie technologieoffen formuliert sind (Issue #77):

1. **Virulenzfaktor** — Nachweis/Ausschluss nun „in einer Probe oder einem Isolat".
2. **Resistenzmechanismen/Determinanten** — Definition erweitert um Proteine und funktionale Tests (z.B. CIM-Test) sowie Isolate; nicht mehr auf molekulare Verfahren beschränkt.
3. **Voraussichtliche Empfindlichkeit** — nun „aus dem Nachweis von Resistenzmechanismen/Genen/Proteinen abgeleitet" statt rein genotypisch.

## Offener Punkt (Rückfrage)
Das Method-ValueSet `MII_VS_Mikrobio_Resistenzmechanismen_Methode_SNOMED` trägt weiterhin die Beschreibung „(molekulare Verfahren)" und listet vermutlich nur molekulare Methoden. Passend zur erweiterten Definition (immunologische/funktionale Tests) müsste ggf. auch dieses ValueSet erweitert werden — dafür werden konkrete SNOMED-Codes benötigt. Nicht Teil dieses PRs.

Closes #77
